### PR TITLE
Add request cancellation to TensorRT LLM backend

### DIFF
--- a/inflight_batcher_llm/src/libtensorrtllm.cc
+++ b/inflight_batcher_llm/src/libtensorrtllm.cc
@@ -620,7 +620,7 @@ public:
             mInProgressWorkItems.emplace(std::make_pair(workItem->requestId(), workItem));
             markedInProgress = true;
         }
-        else if (is_stopped)
+        else
         {
             mStoppedReqIds.erase(workItem->requestId());
         }

--- a/inflight_batcher_llm/src/libtensorrtllm.cc
+++ b/inflight_batcher_llm/src/libtensorrtllm.cc
@@ -608,7 +608,7 @@ public:
         mPendingWorkItemsReqIds.erase(workItem->requestId());
 
         // Check if work item has been stopped
-        bool is_stopped = mStoppedReqIds.find(workItem->requestId()) != mStoppedReqIds.end();
+        bool is_stopped = mStoppedReqIds.count(workItem->requestId());
 
         // Check if the Triton request behind is cancelled
         bool is_cancelled = false;

--- a/inflight_batcher_llm/src/libtensorrtllm.cc
+++ b/inflight_batcher_llm/src/libtensorrtllm.cc
@@ -935,11 +935,7 @@ public:
             bool is_cancelled = false;
             TRITONBACKEND_ResponseFactoryIsCancelled(response_factory, &is_cancelled);
 
-            auto err_code = TRITONSERVER_ERROR_INTERNAL;
-            if (is_cancelled)
-            {
-                err_code = TRITONSERVER_ERROR_CANCELLED;
-            }
+            auto err_code = is_cancelled ? TRITONSERVER_ERROR_CANCELLED : TRITONSERVER_ERROR_INTERNAL;
 
             err = TRITONSERVER_ErrorNew(err_code, errStr.c_str());
             final_response = true;
@@ -1061,10 +1057,7 @@ public:
 
         // Merge cancelled requests into stopped requests Ids
         auto cancelledReqIds = mWorkItemsQueue.getCancelledInProgressReqIds();
-        for (const auto& reqId : cancelledReqIds)
-        {
-            stoppedReqIds.insert(reqId);
-        }
+        stoppedReqIds.insert(cancelledReqIds.begin(), cancelledReqIds.end());
 
         int64_t nStoppedReqIds = static_cast<int64_t>(stoppedReqIds.size());
 

--- a/inflight_batcher_llm/src/libtensorrtllm.cc
+++ b/inflight_batcher_llm/src/libtensorrtllm.cc
@@ -610,7 +610,7 @@ public:
         // Check if work item has been stopped
         bool is_stopped = mStoppedReqIds.count(workItem->requestId());
 
-        // Check if the Triton request behind is cancelled
+        // Check if the Triton request has been cancelled
         bool is_cancelled = false;
         TRITONBACKEND_ResponseFactoryIsCancelled(workItem->response_factory(), &is_cancelled);
 

--- a/inflight_batcher_llm/src/libtensorrtllm.cc
+++ b/inflight_batcher_llm/src/libtensorrtllm.cc
@@ -911,18 +911,19 @@ public:
         TRITONSERVER_Error* err = nullptr;
         if (!errMsg.empty())
         {
+            std::string errStr = "Encountered error for requestId " + std::to_string(requestId) + ": " + errMsg;
+            TLLM_LOG_ERROR(errStr);
+
             bool is_cancelled = false;
             TRITONBACKEND_ResponseFactoryIsCancelled(response_factory, &is_cancelled);
+
+            auto err_code = TRITONSERVER_ERROR_INTERNAL;
             if (is_cancelled)
             {
-                err = TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_CANCELLED, errMsg.c_str());
+                err_code = TRITONSERVER_ERROR_CANCELLED;
             }
-            else
-            {
-                std::string errStr = "Encountered error for requestId " + std::to_string(requestId) + ": " + errMsg;
-                TLLM_LOG_ERROR(errStr);
-                err = TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, errStr.c_str());
-            }
+
+            err = TRITONSERVER_ErrorNew(err_code, errStr.c_str());
             final_response = true;
         }
         else


### PR DESCRIPTION
Once requests are popped from the queue, the cancellation state will be checked. If cancelled, the request will be ignored. Otherwise, it continues normally.