### PR TITLE
Change TensorRT LLM submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tensorrt_llm"]
 	path = tensorrt_llm
-	url = git@github.com:NVIDIA/TensorRT-LLM.git
+	url = https://github.com/NVIDIA/TensorRT-LLM.git


### PR DESCRIPTION
Change the TensorRT LLM submodule url in the `.gitmodules` file.