### PR TITLE
make add_special_tokens/skip_special_tokens default value is true which align with hf setting

### DIFF
--- a/all_models/inflight_batcher_llm/postprocessing/1/model.py
+++ b/all_models/inflight_batcher_llm/postprocessing/1/model.py
@@ -55,9 +55,17 @@ class TritonPythonModel:
         model_config = json.loads(args['model_config'])
         tokenizer_dir = model_config['parameters']['tokenizer_dir'][
             'string_value']
-        self.skip_special_tokens = model_config['parameters'].get(
+
+        self.skip_special_tokens = False
+        skip_special_tokens_str = model_config['parameters'].get(
             'skip_special_tokens',
-            {'string_value': "true"})['string_value'].lower() in [
+            {'string_value': "true"})['string_value'].lower()
+        # if user set skip_special_tokens, use it.
+        if skip_special_tokens_str != '${skip_special_tokens}':
+            assert skip_special_tokens_str.lower() in [
+                'true', 'false', '1', '0', 't', 'f', 'y', 'n', 'yes', 'no'
+            ], "skip_special_tokens must be a boolean string"
+            self.skip_special_tokens = skip_special_tokens_str.lower() in [
                 'true', '1', 't', 'y', 'yes'
             ]
 

--- a/all_models/inflight_batcher_llm/postprocessing/config.pbtxt
+++ b/all_models/inflight_batcher_llm/postprocessing/config.pbtxt
@@ -101,7 +101,7 @@ parameters {
 parameters {
   key: "skip_special_tokens"
   value: {
-    string_value: "True"
+    string_value: "${skip_special_tokens}"
   }
 }
 

--- a/all_models/inflight_batcher_llm/preprocessing/1/model.py
+++ b/all_models/inflight_batcher_llm/preprocessing/1/model.py
@@ -56,9 +56,17 @@ class TritonPythonModel:
         model_config = json.loads(args['model_config'])
         tokenizer_dir = model_config['parameters']['tokenizer_dir'][
             'string_value']
-        self.add_special_tokens = model_config['parameters'].get(
+
+        self.add_special_tokens = True
+        add_special_tokens_str = model_config['parameters'].get(
             'add_special_tokens',
-            {'string_value': "false"})['string_value'].lower() in [
+            {'string_value': "true"})['string_value'].lower()
+        # if user set add_special_tokens, use it.
+        if add_special_tokens_str != '${add_special_tokens}':
+            assert add_special_tokens_str.lower() in [
+                'true', 'false', '1', '0', 't', 'f', 'y', 'n', 'yes', 'no'
+            ], "add_special_tokens must be a boolean string"
+            self.add_special_tokens = add_special_tokens_str.lower() in [
                 'true', '1', 't', 'y', 'yes'
             ]
 


### PR DESCRIPTION
For HF ```Tokenizer.encode```, the ```add_special_tokens``` default value is ```True```(https://huggingface.co/transformers/v2.11.0/main_classes/tokenizer.html#transformers.PreTrainedTokenizer.encode), but tensorrtllm_backend default value is ```Flase```, and if the user doesn't set it at ```preprocessing/config.pbtxt```, there may have some issues: https://github.com/triton-inference-server/tensorrtllm_backend/issues/445 and https://github.com/triton-inference-server/tensorrtllm_backend/issues/434. I think we need to align the behavior of tensorrtllm_backend with HF and not expect the user to set it before launching a model server(same as ```Tokenizer.decode```).