### PR TITLE
Replace subprocess.Popen with subprocess.run 

### DIFF
--- a/scripts/launch_triton_server.py
+++ b/scripts/launch_triton_server.py
@@ -111,4 +111,4 @@ if __name__ == '__main__':
     if args.multi_model:
         assert args.world_size == 1, 'World size must be 1 when using multi-model. Processes will be spawned automatically to run the multi-GPU models'
         env['TRTLLM_ORCHESTRATOR'] = '1'
-    subprocess.Popen(cmd, env=env)
+    subprocess.run(cmd, env=env, check=True)


### PR DESCRIPTION
The use of `Popen `creates a non-blocking subprocess. When launching Docker containers in detached mode (`-d` flag) this causes the container to start and then immediately stop, since the main thread within the container has completed all tasks. In addition, there are no logs or errors generated upon exit.

As it is very common to launch containers in detached mode and the `launch_triton_server.py` may be specified as the entry point, using `run` follows Docker best practices by having `tritonserver` run as the main process (https://docs.docker.com/config/containers/multi-service_container/).