### PR TITLE
fix inference quality caused by temperature parameter in bls

### DIFF
--- a/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
+++ b/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
@@ -339,6 +339,7 @@ class TritonDecoder(Decoder):
             "stream": "streaming",
             "prompt_embedding_table": "prompt_embedding_table",
             "prompt_vocab_size": "prompt_vocab_size",
+            "temperature": "temperature",
         }
         tensors = self.create_triton_tensors(request, name_map)
 


### PR DESCRIPTION
When the prompt and parameters are the same, I use APIs of ensemble and tensorrt_llm_bls, the results are different.

And the result of `ensemble` is expected.

I analyzed the code of bls and finally found that the inference quality dropped significantly in some scenarios, because the `temperature` parameters were not given.

What's more, this problem has led to many bad cases in our prod services.

After fixing the `temperature` problem, the scores of blue and em are close to `vllm` of `fp16`, here is the comparative data:
<img width="452" alt="image" src="https://github.com/triton-inference-server/tensorrtllm_backend/assets/34408100/65c2dbbf-1f1b-437e-9c1f-09a2330df0c3">


Here is the code: [name_map](https://github.com/triton-inference-server/tensorrtllm_backend/blob/4d399bc75426263be9b31b66d42e4db81b73b6f7/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py#L328)


And I have added an issue before.
https://github.com/triton-inference-server/tensorrtllm_backend/issues/520