### PR TITLE
fix: Fix typo with 'false' and pre-commit failures

### DIFF
--- a/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -7,13 +7,12 @@ from random import randint
 from threading import Lock, Thread
 
 import numpy as np
+import tensorrt_llm.bindings.executor as trtllm
+import tensorrt_llm.logger as logger
 import torch
 import triton_python_backend_utils as pb_utils
 from torch import from_numpy
 from torch.utils.dlpack import from_dlpack
-
-import tensorrt_llm.bindings.executor as trtllm
-import tensorrt_llm.logger as logger
 
 
 def mpi_comm():
@@ -321,7 +320,7 @@ def convert_request(request, exclude_input_from_output, decoupled):
             # if request doesn't specify exclude_input_from_output, try to use the parameter
             output_config.exclude_input_from_output = (
                 exclude_input_from_output
-                if exclude_input_from_output is not None else false)
+                if exclude_input_from_output is not None else False)
         else:
             output_config.exclude_input_from_output = req_exclude_input_from_output
 


### PR DESCRIPTION
Fixes this obscure error when running the python backend implementation of the `tensorrt_llm` model:

```
tritonclient.utils.InferenceServerException: Traceback (most recent call last):
  File "/mnt/triton/hackathon/trtllm/tensorrtllm_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py", line 108, in execute
    for res in res_gen:
  File "/mnt/triton/hackathon/trtllm/tensorrtllm_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py", line 230, in decode
    for gen_response in self._generate(
  File "/mnt/triton/hackathon/trtllm/tensorrtllm_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py", line 295, in _generate
    for r in self._exec_triton_request(triton_req):
  File "/mnt/triton/hackathon/trtllm/tensorrtllm_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py", line 109, in _exec_triton_request
    raise pb_utils.TritonModelException(r.error().message())
c_python_backend_utils.TritonModelException: An error occurred when processing the input values for request id , the error was 'name 'false' is not defined'
```