### PR TITLE
[PoC] Improve TRTLLM deployment UX

### DIFF
--- a/all_models/inflight_batcher_llm/ensemble/config.pbtxt
+++ b/all_models/inflight_batcher_llm/ensemble/config.pbtxt
@@ -26,7 +26,7 @@
 
 name: "ensemble"
 platform: "ensemble"
-max_batch_size: ${triton_max_batch_size}
+max_batch_size: 256
 input [
   {
     name: "text_input"

--- a/all_models/inflight_batcher_llm/postprocessing/1/model.py
+++ b/all_models/inflight_batcher_llm/postprocessing/1/model.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import os
 
 import numpy as np
 import triton_python_backend_utils as pb_utils
@@ -53,8 +54,14 @@ class TritonPythonModel:
         """
         # Parse model configs
         model_config = json.loads(args['model_config'])
-        tokenizer_dir = model_config['parameters']['tokenizer_dir'][
-            'string_value']
+        # Support tokenizer dir from env var for central location
+        tokenizer_dir = os.environ.get(
+            "TRTLLM_ENGINE_DIR",
+            model_config['parameters']['tokenizer_dir']['string_value'])
+        if not tokenizer_dir:
+            raise pb_utils.TritonModelException(
+                f"No tokenizer directory set. Please set TRTLLM_ENGINE_DIR env var or 'tokenizer_dir' config field to the directory containing engines and tokenizers."
+            )
 
         skip_special_tokens = model_config['parameters'].get(
             'skip_special_tokens')

--- a/all_models/inflight_batcher_llm/postprocessing/config.pbtxt
+++ b/all_models/inflight_batcher_llm/postprocessing/config.pbtxt
@@ -26,7 +26,7 @@
 
 name: "postprocessing"
 backend: "python"
-max_batch_size: ${triton_max_batch_size}
+max_batch_size: 256
 dynamic_batching {}
 input [
   {
@@ -48,13 +48,15 @@ output [
   }
 ]
 
+# TODO: env var
 parameters {
   key: "tokenizer_dir"
   value: {
-    string_value: "${tokenizer_dir}"
+    string_value: ""
   }
 }
 
+# TODO: Lookup how its filled today
 parameters {
   key: "skip_special_tokens"
   value: {
@@ -64,7 +66,7 @@ parameters {
 
 instance_group [
     {
-        count: ${postprocessing_instance_count}
+        count: 8
         kind: KIND_CPU
     }
 ]

--- a/all_models/inflight_batcher_llm/preprocessing/1/model.py
+++ b/all_models/inflight_batcher_llm/preprocessing/1/model.py
@@ -55,8 +55,14 @@ class TritonPythonModel:
         """
         # Parse model configs
         model_config = json.loads(args['model_config'])
-        tokenizer_dir = model_config['parameters']['tokenizer_dir'][
-            'string_value']
+        # Support tokenizer dir from env var for central location
+        tokenizer_dir = os.environ.get(
+            "TRTLLM_ENGINE_DIR",
+            model_config['parameters']['tokenizer_dir']['string_value'])
+        if not tokenizer_dir:
+            raise pb_utils.TritonModelException(
+                f"No tokenizer directory set. Please set TRTLLM_ENGINE_DIR env var or 'tokenizer_dir' config field to the directory containing engines and tokenizers."
+            )
 
         add_special_tokens = model_config['parameters'].get(
             'add_special_tokens')
@@ -662,9 +668,8 @@ class VisionPreProcessor:
         import requests
         import torch
         from PIL import Image
-        from torch.utils.dlpack import from_dlpack
-
         from tensorrt_llm._utils import str_dtype_to_torch
+        from torch.utils.dlpack import from_dlpack
 
         # create method for loading image from urls
         self.load_images_from_urls = lambda img_urls: [

--- a/all_models/inflight_batcher_llm/preprocessing/config.pbtxt
+++ b/all_models/inflight_batcher_llm/preprocessing/config.pbtxt
@@ -26,7 +26,7 @@
 
 name: "preprocessing"
 backend: "python"
-max_batch_size: ${triton_max_batch_size}
+max_batch_size: 256
 input [
     {
         name: "QUERY"
@@ -177,10 +177,11 @@ output [
     }
 ]
 
+# TODO: Use shared env var
 parameters {
   key: "tokenizer_dir"
   value: {
-    string_value: "${tokenizer_dir}"
+    string_value: ""
   }
 }
 
@@ -198,10 +199,11 @@ parameters {
   }
 }
 
+# TODO: Shared env var
 parameters: {
   key: "gpt_model_path"
   value: {
-    string_value: "${engine_dir}"
+    string_value: ""
   }
 }
 
@@ -214,7 +216,7 @@ parameters: {
 
 instance_group [
     {
-        count: ${preprocessing_instance_count}
+        count: 8
         kind: KIND_CPU
     }
 ]

--- a/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -834,7 +834,10 @@ class TritonPythonModel:
         engine_dir: Path = self.get_engine_dir()
         engines = [engine for engine in engine_dir.glob("*.engine")]
         # Build engine if not found
-        if not engines:
+        if engines:
+            pb_utils.Logger.log_info(
+                f"Found existing engine(s) at {engine_dir}.")
+        else:
             pb_utils.Logger.log_info(f"No engine(s) found at {engine_dir}.")
             model_id: str = os.environ.get("TRTLLM_MODEL")
             if not model_id:
@@ -887,14 +890,23 @@ class TritonPythonModel:
         pb_utils.Logger.log_info(f"Saved engine to {engine_dir}.")
 
     def get_engine_build_config(self):
-        # NOTE: Given config.json, can read from 'build_config' section and from_dict
+        # FIXME: Can't construct BuildConfig directly from **build_config
+        # If a config file exists with a build_config, use it.
+        #config_file = engine_dir / "config.json"
+        #if config_file.exists():
+        #    pb_utils.Logger.log_info(f"Found engine build config at {config_file}.")
+        #    with open(config_file) as f:
+        #        config_json = json.load(f)
+        #        build_config = config_json["build_config"]
+        #    pb_utils.Logger.log_info(f"Using build config: {build_config}")
+        #    config = BuildConfig(**build_config)
+        #else:
+        #    pb_utils.Logger.log_info(f"Using default build config.")
+        #    # Default config if no config file found
+        #    config = BuildConfig()
+
         config = BuildConfig()
-        # TODO: Expose more build args to user
-        # TODO: Discuss LLM API BuildConfig defaults
-        # NOTE: Using some defaults from trtllm-build because LLM API defaults are too low
-        #config.max_input_len = 1024
-        #config.max_seq_len = 8192
-        #config.max_batch_size = 256
+        pb_utils.Logger.log_info(f"Using default build config: {config}")
         return config
 
     def handle_stop_request(self, triton_user_id, response_sender):

--- a/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -882,12 +882,7 @@ class TritonPythonModel:
 
         # TODO: Read from config,json if available
         build_config = self.get_engine_build_config()
-        engine = LLM(
-            model_id,
-            build_config=build_config,
-            # TODO: Needed to avoid OOM here?
-            kv_cache_config=trtllm.KvCacheConfig(free_gpu_memory_fraction=0.1))
-        pb_utils.Logger.log_info(f"Saving engine to {engine_dir}.")
+        engine = LLM(model_id, build_config=build_config)
         engine.save(str(engine_dir))
         pb_utils.Logger.log_info(f"Saved engine to {engine_dir}.")
 

--- a/all_models/inflight_batcher_llm/tensorrt_llm/config.pbtxt
+++ b/all_models/inflight_batcher_llm/tensorrt_llm/config.pbtxt
@@ -25,17 +25,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 name: "tensorrt_llm"
-backend: "${triton_backend}"
-max_batch_size: ${triton_max_batch_size}
+backend: "python"
+max_batch_size: 256
 
 model_transaction_policy {
-  decoupled: ${decoupled_mode}
+  decoupled: True
 }
 
 dynamic_batching {
-    preferred_batch_size: [ ${triton_max_batch_size} ]
-    max_queue_delay_microseconds: ${max_queue_delay_microseconds}
-    default_queue_policy: { max_queue_size: ${max_queue_size} }
+    max_queue_delay_microseconds: 100
+    default_queue_policy: { max_queue_size: 0 }
 }
 
 input [
@@ -433,7 +432,7 @@ output [
 instance_group [
   {
     count: 1
-    kind : KIND_CPU
+    kind : KIND_MODEL
   }
 ]
 parameters: {
@@ -451,9 +450,10 @@ parameters: {
 parameters: {
   key: "gpt_model_type"
   value: {
-    string_value: "${batching_strategy}"
+    string_value: "inflight_fused_batching"
   }
 }
+# TODO: env var
 parameters: {
   key: "gpt_model_path"
   value: {

--- a/all_models/inflight_batcher_llm/tensorrt_llm_bls/config.pbtxt
+++ b/all_models/inflight_batcher_llm/tensorrt_llm_bls/config.pbtxt
@@ -26,10 +26,10 @@
 
 name: "tensorrt_llm_bls"
 backend: "python"
-max_batch_size: ${triton_max_batch_size}
+max_batch_size: 256
 
 model_transaction_policy {
-  decoupled: ${decoupled_mode}
+  decoupled: True
 }
 
 input [
@@ -330,7 +330,7 @@ parameters: {
 
 instance_group [
   {
-    count: ${bls_instance_count}
+    count: 1
     kind : KIND_CPU
   }
 ]


### PR DESCRIPTION
## Changes
- Remove mandatory template values in configs with some sensible defaults
- Support building TRTLLM engine on model load if none found using LLM API
- Add env vars for conveniently configuring engine and tokenizers from a single location instead of specifying it in all the model configs

## Example Usage

### Quickstart - no engine, no tokenizer, build on demand
```bash
# Launch TRTLLM container
docker run -ti \
    --gpus all \
    --network=host \
    --shm-size=1g \
    --ulimit memlock=-1 \
    -e HF_TOKEN \
    -v ${HOME}:/mnt \
    -v ${HOME}/.cache/huggingface:/root/.cache/huggingface \
    nvcr.io/nvidia/tritonserver:24.10-trtllm-python-py3

# Clone these changes
git clone -b rmccormick/ux https://github.com/triton-inference-server/tensorrtllm_backend.git

# Specify directory for engines and tokenizer config to either be read from, or written to
export TRTLLM_ENGINE_DIR="/tmp/hackathon"
# Specify model to build if TRTLLM_ENGINE_DIR has no engines
export TRTLLM_MODEL="meta-llama/Meta-Llama-3.1-8B-Instruct"
# Workaround to support HF Tokenizer while engine is being built on demand to avoid
# ordering issues with model loading, or if tokenizer exists in a different location.
export TRTLLM_TOKENIZER="meta-llama/Meta-Llama-3.1-8B-Instruct"

# Start server
tritonserver --model-repository ./tensorrtllm_backend/all_models/inflight_batcher_llm
```

### Pre-built engine + tokenizer already in same location

```bash
export TRTLLM_ENGINE_DIR="/tmp/hackathon"

# Start server
tritonserver --model-repository ./tensorrtllm_backend/all_models/inflight_batcher_llm
```

### Pre-built engine + tokenizer in different locations

```bash
export TRTLLM_ENGINE_DIR="/tmp/hackathon"
export TRTLLM_TOKENIZER="meta-llama/Meta-Llama-3.1-8B-Instruct"

# Start server
tritonserver --model-repository ./tensorrtllm_backend/all_models/inflight_batcher_llm
```

### Further customization/configuration

Manually tune/configure values in the `config.pbtxt` files as needed for tuning Triton or TRT-LLM runtime fields.

## Open Items
- [x] Ordering: If engine and tokenizer don't exist, and preprocessing/postprocessing models load before tensorrt_llm model builds engine and downloads tokenizer, then they will fail to load with no tokenizer found.
    - [x] Added TRTLLM_TOKENIZER env var as a WAR for the ordering issue for now.
- [ ] Support building engine from a TRTLLM-generated `config.json` if config is found but engines are not
- [ ] Support configuring more TRTLLM backend/runtime fields from the engine's `config.json`
- [ ] Test multi-gpu engine (ex: Llama 70B)
- [ ] Re-use common logic around tokenizer / env vars in preprocessing and postprocessing models


<summary> [Extra] Probably not in scope for this PR, but there is also a Python Model shutdown segfault </summary>

<details>

```bash
[ced35d0-lcedt:2992 :0:2992] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x60)
==== backtrace (tid:   2992) ====
 0 0x0000000000042520 __sigaction()  ???:0
 1 0x00000000000b44d0 triton::backend::python::Metric::SaveToSharedMemory()  :0
 2 0x00000000000b536e triton::backend::python::Metric::Clear()  :0
 3 0x00000000000b9291 triton::backend::python::MetricFamily::~MetricFamily()  :0
 4 0x00000000000677f2 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()  ???:0
 5 0x000000000006822a pybind11::class_<triton::backend::python::MetricFamily, std::shared_ptr<triton::backend::python::MetricFamily> >::dealloc()  ???:0
 6 0x0000000000037b5d pybind11::detail::clear_instance()  :0
 7 0x0000000000038b13 pybind11_object_dealloc()  ???:0
 8 0x000000000011bea5 PyODict_DelItem()  ???:0
 9 0x0000000000144b37 PyType_GenericAlloc()  ???:0
10 0x000000000005142e triton::backend::python::Stub::~Stub()  :0
11 0x0000000000028f53 main()  ???:0
12 0x0000000000029d90 __libc_init_first()  ???:0
13 0x0000000000029e40 __libc_start_main()  ???:0
14 0x0000000000029db5 _start()  ???:0
=================================
I1122 22:08:07.287915 2117 model_lifecycle.cc:624] "successfully unloaded 'tensorrt_llm' version 1"
```

</details>