### PR TITLE
[fix] deprecated LABEL syntax in docker build file

### DIFF
--- a/dockerfile/Dockerfile.triton.trt_llm_backend
+++ b/dockerfile/Dockerfile.triton.trt_llm_backend
@@ -97,7 +97,7 @@ ENV TRT_VERSION=$TRT_VER \
     CUBLAS_VER=$CUBLAS_VERSION \
     NVRTC_VER="${NVRTC_VER}"
 
-LABEL TRT_VERSION $TRT_VER
+LABEL TRT_VERSION="$TRT_VER"
 
 # Install NVRTC
 RUN [ "$(uname -m)" != "x86_64" ] && arch="sbsa" || arch="x86_64" \


### PR DESCRIPTION
The current docker version will report an error about deprecated usage warning `- LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 100)` and fail the build. Updating to the valid way to define this variable.
Latest label usage: https://docs.docker.com/reference/dockerfile/#label