### PR TITLE
docs: Remove TensorRT engine backend references

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ repo. If you don't find your answer there you can ask questions on the
 - [TensorRT-LLM Backend](#tensorrt-llm-backend)
   - [Table of Contents](#table-of-contents)
   - [Getting Started](#getting-started)
-    - [PyTorch Backend (LLM API) — Simpler Setup](#pytorch-backend-llm-api--simpler-setup)
+    - [PyTorch Backend (LLM API)](#pytorch-backend-llm-api)
       - [Launch the container](#launch-the-container)
       - [Clone TRT-LLM and set your model](#clone-trt-llm-and-set-your-model)
       - [Launch and test](#launch-and-test)
       - [Cancel an in-flight request](#cancel-an-in-flight-request)
-    - [TensorRT Engine Backend](#tensorrt-engine-backend)
   - [Building from Source](#building-from-source)
   - [Supported Models](#supported-models)
   - [Model Config](#model-config)
@@ -83,11 +82,10 @@ repo. If you don't find your answer there you can ask questions on the
   - [Triton Metrics](#triton-metrics)
   - [Benchmarking](#benchmarking)
   - [Testing the TensorRT-LLM Backend](#testing-the-tensorrt-llm-backend)
-  - [TensorRT Engine Backend](#tensorrt-engine-backend-1)
 
 ## Getting Started
 
-### PyTorch Backend (LLM API) — Simpler Setup
+### PyTorch Backend (LLM API)
 
 Serve any HuggingFace model directly — no engine compilation required.
 
@@ -162,15 +160,6 @@ curl -X POST localhost:8000/v2/models/tensorrt_llm/generate \
 The server stops generation immediately and returns a cancellation response.
 
 For multi-GPU, multi-node, and advanced options see [`docs/llmapi.md`](./docs/llmapi.md).
-
----
-
-### TensorRT Engine Backend
-
-For workflows using pre-compiled TensorRT engines (`trtllm-build`), see the
-[TensorRT Engine Backend](#tensorrt-engine-backend-1) section at the bottom of this page.
-
----
 
 ## Building from Source
 
@@ -275,44 +264,33 @@ and
 [Expert parallelism](https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/features/parallelisms.html#expert-parallelism)
 are supported in TensorRT-LLM.
 
-See the models in the
-[examples](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples) folder for
-more details on how to build the engines with tensor parallelism, pipeline
-parallelism and expert parallelism.
+With the LLM API, parallelism is configured directly in `model.yaml`; the keys
+map to the [`LLM()` constructor arguments](https://nvidia.github.io/TensorRT-LLM/llm-api/).
 
 Some examples are shown below:
 
-- Build LLaMA v3 70B using 4-way tensor parallelism and 2-way pipeline parallelism.
+- Serve LLaMA v3 70B using 4-way tensor parallelism and 2-way pipeline parallelism.
 
-```bash
-python3 convert_checkpoint.py --model_dir ./tmp/llama/70B/hf/ \
-                            --output_dir ./tllm_checkpoint_8gpu_tp4_pp2 \
-                            --dtype float16 \
-                            --tp_size 4 \
-                            --pp_size 2
-
-trtllm-build --checkpoint_dir ./tllm_checkpoint_8gpu_tp4_pp2 \
-            --output_dir ./tmp/llama/70B/trt_engines/fp16/8-gpu/ \
-            --gemm_plugin auto
+```yaml
+model: meta-llama/Meta-Llama-3-70B
+tensor_parallel_size: 4
+pipeline_parallel_size: 2
 ```
 
-- Build Mixtral8x22B with tensor parallelism and expert parallelism
+- Serve Mixtral 8x22B with tensor parallelism and expert parallelism, using the
+  Mixture of Experts (MoE) parallelism keys `moe_expert_parallel_size` and
+  `moe_tensor_parallel_size`.
 
-```bash
-python3 ../llama/convert_checkpoint.py --model_dir ./Mixtral-8x22B-v0.1 \
-                             --output_dir ./tllm_checkpoint_mixtral_8gpu \
-                             --dtype float16 \
-                             --tp_size 8 \
-                             --moe_tp_size 2 \
-                             --moe_ep_size 4
-trtllm-build --checkpoint_dir ./tllm_checkpoint_mixtral_8gpu \
-                 --output_dir ./trt_engines/mixtral/tp2ep4 \
-                 --gemm_plugin float16
+```yaml
+model: mistralai/Mixtral-8x22B-v0.1
+tensor_parallel_size: 8
+moe_expert_parallel_size: 4
+moe_tensor_parallel_size: 2
 ```
 
 See the
-[doc](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/legacy/advanced/expert-parallelism.md)
-to learn more about how TensorRT-LLM expert parallelism works in Mixture of Experts (MoE).
+[LLM API reference](https://nvidia.github.io/TensorRT-LLM/llm-api/)
+to learn more about how TensorRT-LLM supports expert parallelism in Mixture of Experts (MoE).
 
 ### MIG Support
 
@@ -334,9 +312,9 @@ See the
 [KV Cache](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/legacy/advanced/gpt-attention.md#kv-cache)
 section for more details on how TensorRT-LLM supports KV cache. Also, check out
 the [KV Cache Reuse](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/legacy/advanced/kv-cache-reuse.md)
-documentation to learn more about how to enable KV cache reuse when building the
-TRT-LLM engine. Parameters for KV cache can be found in the
-[model config](./docs/model_config.md#tensorrt_llm-model) of tensorrt_llm model.
+documentation to learn more about how to enable KV cache reuse. KV cache options
+are configured through the [LLM API](https://nvidia.github.io/TensorRT-LLM/llm-api/)
+in `model.yaml`.
 
 ### Decoding
 
@@ -591,287 +569,3 @@ Expected outputs
 ## Testing the TensorRT-LLM Backend
 Please follow the guide in [`tensorrt_llm/triton_backend/ci/README.md`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/triton_backend/ci/README.md) to see how to run
 the testing for TensorRT-LLM backend.
-
----
-
-## TensorRT Engine Backend
-
-> [!NOTE]
-> This section covers the workflow using pre-compiled TensorRT engines (`trtllm-build`) and the `inflight_batcher_llm` model layout. This path has full automated CI coverage. For a simpler setup without engine compilation, see the [PyTorch Backend (LLM API)](#pytorch-backend-llm-api--simpler-setup) above.
-
-Below is an example of how to serve a TensorRT-LLM model with the Triton
-TensorRT-LLM Backend on a 4-GPU environment. The example uses the GPT model from
-the
-[TensorRT-LLM repository](https://github.com/NVIDIA/TensorRT-LLM/tree/v0.11.0/examples/gpt)
-with the
-[NGC Triton TensorRT-LLM container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver).
-Make sure you are cloning the same version of TensorRT-LLM backend as the
-version of TensorRT-LLM in the container. Please refer to the
-[support matrix](https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html)
-to see the aligned versions.
-
-In this example, we will use Triton 24.07 with TensorRT-LLM v0.11.0.
-
-### Launch Triton TensorRT-LLM container
-
-Launch Triton docker container `nvcr.io/nvidia/tritonserver:<xx.yy>-trtllm-python-py3`
-with TensorRT-LLM backend.
-
-Make an `engines` folder outside docker to reuse engines for future runs. Make
-sure to replace the `<xx.yy>` with the version of Triton that you want to use.
-
-```bash
-docker run --rm -it --net host --shm-size=2g \
-    --ulimit memlock=-1 --ulimit stack=67108864 --gpus all \
-    -v </path/to/engines>:/engines \
-    nvcr.io/nvidia/tritonserver:24.07-trtllm-python-py3
-```
-
-### Prepare TensorRT-LLM engines
-
-You can skip this step if you already have the engines ready.
-Follow the [guide](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples) in
-TensorRT-LLM repository for more details on how to prepare the engines for
-all the supported models. You can also check out the
-[tutorials](https://github.com/triton-inference-server/tutorials) to see more
-examples with serving TensorRT-LLM models.
-
-```bash
-cd /app/tensorrt_llm/examples/models/core/gpt
-
-# Download weights from HuggingFace Transformers
-rm -rf gpt2 && git clone https://huggingface.co/gpt2-medium gpt2
-pushd gpt2 && rm pytorch_model.bin model.safetensors && wget -q https://huggingface.co/gpt2-medium/resolve/main/pytorch_model.bin && popd
-
-# Convert weights from HF Transformers to TensorRT-LLM checkpoint
-python3 convert_checkpoint.py --model_dir gpt2 \
-        --dtype float16 \
-        --tp_size 4 \
-        --output_dir ./c-model/gpt2/fp16/4-gpu
-
-# Build TensorRT engines
-trtllm-build --checkpoint_dir ./c-model/gpt2/fp16/4-gpu \
-        --gpt_attention_plugin float16 \
-        --remove_input_padding enable \
-        --kv_cache_type paged \
-        --gemm_plugin float16 \
-        --output_dir /engines/gpt/fp16/4-gpu
-```
-
-See [here](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/models/core/gpt) for
-more details on the parameters.
-
-### Prepare the Model Repository
-
-Next, create the
-[model repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md)
-that will be used by the Triton server. The models can be found in the
-[all_models](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/all_models) folder. The folder contains six groups of models:
-- [`disaggregated_serving`](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/all_models/disaggregated_serving): Using the C++ TensorRT-LLM backend to run disaggregated serving.
-- [`gpt`](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/all_models/gpt): Using TensorRT-LLM pure Python runtime. This model is deprecated and will be removed in a future release.
-- [`inflight_batcher_llm`](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/all_models/inflight_batcher_llm): Using the C++
-TensorRT-LLM backend with the executor API, which includes the latest features
-including inflight batching.
-
-There are five models in
-[all_models/inflight_batcher_llm](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/all_models/inflight_batcher_llm) that will
-be used in this example:
-
-| Model              | Description |
-| :----------------- | :---------- |
-| `ensemble`         | Chains the preprocessing, tensorrt_llm, and postprocessing models together. |
-| `preprocessing`    | Tokenizes input: converts prompts (string) to input_ids (list of ints). |
-| `tensorrt_llm`     | Wraps the TRT-LLM model and runs inference. Input specification can be found [here](./docs/model_config.md#model-input-and-output). |
-| `postprocessing`   | Detokenizes output: converts output_ids (list of ints) to text (string). |
-| `tensorrt_llm_bls` | Alternative to the ensemble model for chaining pre/post-processing with the TRT-LLM model. |
-
-To learn more about ensemble and BLS models, please see the
-[Ensemble Models](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/architecture.md#ensemble-models)
-and
-[Business Logic Scripting](https://github.com/triton-inference-server/python_backend#business-logic-scripting)
-documentation.
-
-To learn more about the benefits and the limitations of using the BLS model,
-please see the [model config](./docs/model_config.md#tensorrt_llm_bls-model) section.
-
-```bash
-mkdir /triton_model_repo
-cp -r /app/all_models/inflight_batcher_llm/* /triton_model_repo/
-```
-
-### Modify the Model Configuration
-
-Use the script to fill in the parameters in the model configuration files. For
-optimal performance or custom parameters, please refer to
-[performance-tuning-guide](https://github.com/NVIDIA/TensorRT-LLM/tree/main/docs/source/legacy/performance/performance-tuning-guide).
-For more details on the model configuration and the parameters that can be
-modified, please refer to the [model config](./docs/model_config.md) section.
-
-```bash
-ENGINE_DIR=/engines/gpt/fp16/4-gpu
-TOKENIZER_DIR=/app/tensorrt_llm/examples/models/core/gpt/gpt2
-MODEL_FOLDER=/triton_model_repo
-TRITON_MAX_BATCH_SIZE=4
-INSTANCE_COUNT=1
-MAX_QUEUE_DELAY_MS=0
-MAX_QUEUE_SIZE=0
-FILL_TEMPLATE_SCRIPT=/app/tools/fill_template.py
-DECOUPLED_MODE=false
-LOGITS_DATATYPE=TYPE_FP32
-
-python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/ensemble/config.pbtxt triton_max_batch_size:${TRITON_MAX_BATCH_SIZE},logits_datatype:${LOGITS_DATATYPE}
-python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/preprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},triton_max_batch_size:${TRITON_MAX_BATCH_SIZE},preprocessing_instance_count:${INSTANCE_COUNT}
-python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm/config.pbtxt triton_backend:tensorrtllm,triton_max_batch_size:${TRITON_MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},engine_dir:${ENGINE_DIR},max_queue_delay_microseconds:${MAX_QUEUE_DELAY_MS},batching_strategy:inflight_fused_batching,max_queue_size:${MAX_QUEUE_SIZE},encoder_input_features_data_type:TYPE_FP16,logits_datatype:${LOGITS_DATATYPE}
-python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/postprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},triton_max_batch_size:${TRITON_MAX_BATCH_SIZE},postprocessing_instance_count:${INSTANCE_COUNT}
-python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm_bls/config.pbtxt triton_max_batch_size:${TRITON_MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},bls_instance_count:${INSTANCE_COUNT},logits_datatype:${LOGITS_DATATYPE}
-```
-
-> **NOTE**:
-> It is recommended to match the number of pre/post_instance_counts with triton_max_batch_size for better performance.
-
-### Serving with Triton
-
-Now, you're ready to launch the Triton server with the TensorRT-LLM model.
-
-Use the launch_triton_server.py script. This launches multiple instances of tritonserver with MPI.
-
-```bash
-# 'world_size' is the number of GPUs you want to use for serving. This should
-# be aligned with the number of GPUs used to build the TensorRT-LLM engine.
-python3 /app/scripts/launch_triton_server.py --world_size=4 --model_repo=${MODEL_FOLDER}
-```
-
-You should see the following logs when the server is successfully deployed.
-
-```bash
-...
-I0503 22:01:25.210518 1175 grpc_server.cc:2463] Started GRPCInferenceService at 0.0.0.0:8001
-I0503 22:01:25.211612 1175 http_server.cc:4692] Started HTTPService at 0.0.0.0:8000
-I0503 22:01:25.254914 1175 http_server.cc:362] Started Metrics Service at 0.0.0.0:8002
-```
-
-To stop Triton Server inside the container, run:
-
-```bash
-pkill tritonserver
-```
-
-### Send an Inference Request
-
-#### Using the [generate endpoint](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_generate.md)
-
-The general format of the generate endpoint:
-```bash
-curl -X POST localhost:8000/v2/models/${MODEL_NAME}/generate -d '{"{PARAM1_KEY}": "{PARAM1_VALUE}", ... }'
-```
-
-In the case of the models used in this example, you can replace MODEL_NAME with
-`ensemble` or `tensorrt_llm_bls`. Examining the ensemble and tensorrt_llm_bls
-model's config.pbtxt file, you can see that 4 parameters are required to
-generate a response for this model:
-
-- text_input: Input text to generate a response from
-- max_tokens: The number of requested output tokens
-- bad_words: A list of bad words (can be empty)
-- stop_words: A list of stop words (can be empty)
-
-Therefore, we can query the server in the following way:
-
-- if using the ensemble model
-
-    ```bash
-    curl -X POST localhost:8000/v2/models/ensemble/generate -d '{"text_input": "What is machine learning?", "max_tokens": 20, "bad_words": "", "stop_words": ""}'
-    ```
-
-- if using the tensorrt_llm_bls model
-
-    ```bash
-    curl -X POST localhost:8000/v2/models/tensorrt_llm_bls/generate -d '{"text_input": "What is machine learning?", "max_tokens": 20, "bad_words": "", "stop_words": ""}'
-    ```
-
-Which should return a result similar to (formatted for readability):
-```bash
-{
-  "model_name": "ensemble",
-  "model_version": "1",
-  "sequence_end": false,
-  "sequence_id": 0,
-  "sequence_start": false,
-  "text_output": "What is machine learning?\n\nMachine learning is a method of learning by using machine learning algorithms to solve problems.\n\n"
-}
-```
-
-#### Using the client scripts
-
-You can refer to the client scripts in the
-[inflight_batcher_llm/client](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/inflight_batcher_llm/client) to see how to send
-requests via Python scripts.
-
-Below is an example of using
-[inflight_batcher_llm_client](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/inflight_batcher_llm/client/inflight_batcher_llm_client.py)
-to send requests to the `tensorrt_llm` model.
-
-```bash
-pip3 install tritonclient[all]
-INFLIGHT_BATCHER_LLM_CLIENT=/app/inflight_batcher_llm/client/inflight_batcher_llm_client.py
-python3 ${INFLIGHT_BATCHER_LLM_CLIENT} --request-output-len 200 --tokenizer-dir ${TOKENIZER_DIR}
-```
-
-##### Early stopping
-
-You can also stop the generation process early by using the `--stop-after-ms`
-option to send a stop request after a few milliseconds:
-
-```bash
-python3 ${INFLIGHT_BATCHER_LLM_CLIENT} --stop-after-ms 200 --request-output-len 200 --request-id 1 --tokenizer-dir ${TOKENIZER_DIR}
-```
-
-You will find that the generation process is stopped early and therefore the
-number of generated tokens is lower than 200. You can have a look at the
-client code to see how early stopping is achieved.
-
-##### Return context logits and/or generation logits
-
-If you want to get context logits and/or generation logits, you need to enable
-`--gather_context_logits` and/or `--gather_generation_logits` when building the
-engine (or `--gather_all_token_logits` to enable both at the same time). For
-more setting details about these two flags, please refer to
-[build.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/commands/build.py)
-or
-[gpt_runtime](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/legacy/advanced/gpt-runtime.md).
-
-After launching the server, you could get the output of logits by passing the
-corresponding parameters `--return-context-logits` and/or
-`--return-generation-logits` in the client scripts
-([end_to_end_grpc_client.py](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/inflight_batcher_llm/client/end_to_end_grpc_client.py)
-and
-[inflight_batcher_llm_client.py](https://github.com/NVIDIA/TensorRT-LLM/tree/main/triton_backend/inflight_batcher_llm/client/inflight_batcher_llm_client.py)).
-
-For example:
-
-```bash
-python3 ${INFLIGHT_BATCHER_LLM_CLIENT} --request-output-len 20 --tokenizer-dir ${TOKENIZER_DIR} --return-context-logits --return-generation-logits
-```
-
-#### Requests with batch size > 1
-
-The TRT-LLM backend supports requests with batch size greater than one. When
-sending a request with a batch size greater than one, the TRT-LLM backend will
-return multiple batch size 1 responses, where each response will be associated
-with a given batch index. An output tensor named `batch_index` is associated
-with each response to indicate which batch index this response corresponds to.
-
-The client script
-[end_to_end_grpc_client.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/triton_backend/inflight_batcher_llm/client/end_to_end_grpc_client.py)
-demonstrates how a client can send requests with batch size > 1 and consume the
-responses returned from Triton. When passing `--batch-inputs` to the client
-script, the client will create a request with multiple prompts, and use the
-`batch_index` output tensor to associate the responses to the original prompt.
-
-For example one could run:
-
-```bash
-python3 /app/inflight_batcher_llm/client/end_to_end_grpc_client.py -o 5 -p '["This is a test","I want you to","The cat is"]' --batch-inputs
-```
-
-to send a request with a batch size of 3 to the Triton server.


### PR DESCRIPTION
Remove all references to the TensorRT engine backend from the README, since TensorRT-LLM is dropping the TRT engine code and those instructions will no longer work. This drops the dedicated engine-backend section, its table-of-contents entries and the getting-started pointer, and rewrites the model-parallelism and KV-cache guidance to use the LLM API model.yaml instead of trtllm-build.