### PR TITLE
fix: Remove opencv-python-headless from TensorRT-LLM image

### DIFF
--- a/dockerfile/Dockerfile.triton.trt_llm_backend
+++ b/dockerfile/Dockerfile.triton.trt_llm_backend
@@ -159,8 +159,10 @@ ARG TENSORRTLLM_VER
 RUN --mount=type=secret,id=pypi_extra_values,env=PYPI_EXTRA_VALUES \
     if [ -n "${PYPI_EXTRA_VALUES}" ]; then \
         pip3 install --no-cache-dir ${PYPI_EXTRA_VALUES} ; \
+        pip3 uninstall -y opencv-python-headless || true; \
     else \
         pip3 install --no-cache-dir --extra-index-url https://pypi.nvidia.com tensorrt_llm==${TENSORRTLLM_VER} ; \
+        pip3 uninstall -y opencv-python-headless || true; \
     fi
 
 RUN find /usr /opt -name libtensorrt_llm.so -exec dirname {} \; | sort -u > /etc/ld.so.conf.d/tensorrt-llm.conf \


### PR DESCRIPTION
## Description

New OSRB guidance makes `opencv-python-headless` an immediate blocker for new releases. The TensorRT-LLM backend pulls the package in transitively through the `tensorrt_llm` wheel installed in `dockerfile/Dockerfile.triton.trt_llm_backend`, so it lands in the Triton TensorRT-LLM container image.

This removes the package in the **same layer** where `tensorrt_llm` is installed, running `pip3 uninstall -y opencv-python-headless` on both install paths (the `PYPI_EXTRA_VALUES` branch and the public `pypi.nvidia.com` branch). The `|| true` guard keeps the build green when the package is not present.

## Changes

- `dockerfile/Dockerfile.triton.trt_llm_backend`: uninstall `opencv-python-headless` in the same `RUN` layer as the `tensorrt_llm` install, on both the extra-values and public-wheel branches.

#### Related Issues:
- Resolves: TRI-1564

<sup>
CI (internal): [#57992661](http://tritonserver.local/ci/pipelines/57992661)<br/>
</sup>
